### PR TITLE
Added documentation to the ReadString syscall. It should fix issue #11

### DIFF
--- a/rars/riscv/syscalls/SyscallReadString.java
+++ b/rars/riscv/syscalls/SyscallReadString.java
@@ -48,7 +48,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // TODO: delete, this is redundent in light of the read syscall, just add on the newline in user code and done
 public class SyscallReadString extends AbstractSyscall {
     public SyscallReadString() {
-        super("PrintString", "Reads a string from the console",
+        super("ReadString", "Reads a string from the console",
                 "a0 = address of input buffer<br>a1 = maximum number of characters to read", "N/A");
     }
 

--- a/rars/riscv/syscalls/SyscallReadString.java
+++ b/rars/riscv/syscalls/SyscallReadString.java
@@ -48,7 +48,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // TODO: delete, this is redundent in light of the read syscall, just add on the newline in user code and done
 public class SyscallReadString extends AbstractSyscall {
     public SyscallReadString() {
-        super("ReadString");
+        super("PrintString", "Reads a string from the console",
+                "a0 = address of input buffer<br>a1 = maximum number of characters to read", "N/A");
     }
 
     public void simulate(ProgramStatement statement) throws ExitingException {


### PR DESCRIPTION
At the URJC university in Madrid we are using the RARs simulator for teaching RISC-v
We use the ReadString syscall a lot. But sometimes is annoying for the student because of the lack of documentation. I hope this pull-request fix that 