### PR TITLE
Introduce JSoftFloat to solve floating point bugs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "src/jsoftfloat"]
+	path = src/jsoftfloat
+	url = https://github.com/thethirdone/jsoftfloat/
+	branch = submodule

--- a/src/rars/riscv/instructions/FADDS.java
+++ b/src/rars/riscv/instructions/FADDS.java
@@ -27,12 +27,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FADDS extends Floating {
     public FADDS() {
         super("fadd.s", "Floating ADD: assigns f1 to f2 + f3", "0000000");
     }
 
-    public float compute(float f1, float f2) {
-        return f1 + f2;
+    @Override
+    public Float32 compute(Float32 f1, Float32 f2, Environment e) {
+        return jsoftfloat.operations.Arithmetic.add(f1,f2,e);
     }
 }

--- a/src/rars/riscv/instructions/FCVTSW.java
+++ b/src/rars/riscv/instructions/FCVTSW.java
@@ -1,10 +1,15 @@
 package rars.riscv.instructions;
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
+import rars.SimulationException;
 import rars.riscv.hardware.FloatingPointRegisterFile;
 import rars.riscv.hardware.RegisterFile;
 import rars.riscv.BasicInstruction;
 import rars.riscv.BasicInstructionFormat;
+
+import java.math.BigInteger;
 
 /*
 Copyright (c) 2017,  Benjamin Landers
@@ -39,9 +44,14 @@ public class FCVTSW extends BasicInstruction {
                 BasicInstructionFormat.I_FORMAT, "1101000 00000 sssss ttt fffff 1010011");
     }
 
-    public void simulate(ProgramStatement statement) {
+    public void simulate(ProgramStatement statement) throws SimulationException {
         int[] operands = statement.getOperands();
-        FloatingPointRegisterFile.setRegisterToFloat(operands[0], (float) RegisterFile.getValue(operands[1]));
+        Environment e = new Environment();
+        e.mode = Floating.getRoundingMode(operands[2],statement);
+        Float32 tmp = new Float32(0);
+        Float32 converted = jsoftfloat.operations.Conversions.convertFromInt(BigInteger.valueOf(RegisterFile.getValue(operands[1])),e,tmp);
+        Floating.setfflags(e);
+        FloatingPointRegisterFile.updateRegister(operands[0],converted.bits);
     }
 }
 

--- a/src/rars/riscv/instructions/FCVTSWU.java
+++ b/src/rars/riscv/instructions/FCVTSWU.java
@@ -1,10 +1,15 @@
 package rars.riscv.instructions;
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
+import rars.SimulationException;
 import rars.riscv.hardware.FloatingPointRegisterFile;
 import rars.riscv.hardware.RegisterFile;
 import rars.riscv.BasicInstruction;
 import rars.riscv.BasicInstructionFormat;
+
+import java.math.BigInteger;
 
 /*
 Copyright (c) 2017,  Benjamin Landers
@@ -39,9 +44,14 @@ public class FCVTSWU extends BasicInstruction {
                 BasicInstructionFormat.I_FORMAT, "1101000 00001 sssss ttt fffff 1010011");
     }
 
-    public void simulate(ProgramStatement statement) {
+    public void simulate(ProgramStatement statement) throws SimulationException {
         int[] operands = statement.getOperands();
-        FloatingPointRegisterFile.setRegisterToFloat(operands[0], (float) (RegisterFile.getValue(operands[1]) & 0xFFFFFFFFL));
+        Environment e = new Environment();
+        e.mode = Floating.getRoundingMode(operands[2],statement);
+        Float32 tmp = new Float32(0);
+        Float32 converted = jsoftfloat.operations.Conversions.convertFromInt(BigInteger.valueOf(RegisterFile.getValue(operands[1]) &0xFFFFFFFFL),e,tmp);
+        Floating.setfflags(e);
+        FloatingPointRegisterFile.updateRegister(operands[0],converted.bits);
     }
 }
 

--- a/src/rars/riscv/instructions/FCVTWS.java
+++ b/src/rars/riscv/instructions/FCVTWS.java
@@ -1,12 +1,17 @@
 package rars.riscv.instructions;
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
+import rars.SimulationException;
 import rars.assembler.DataTypes;
 import rars.riscv.hardware.ControlAndStatusRegisterFile;
 import rars.riscv.hardware.FloatingPointRegisterFile;
 import rars.riscv.hardware.RegisterFile;
 import rars.riscv.BasicInstruction;
 import rars.riscv.BasicInstructionFormat;
+
+import java.math.BigInteger;
 
 /*
 Copyright (c) 2017,  Benjamin Landers
@@ -41,19 +46,14 @@ public class FCVTWS extends BasicInstruction {
                 BasicInstructionFormat.I_FORMAT, "1100000 00000 sssss ttt fffff 1010011");
     }
 
-    public void simulate(ProgramStatement statement) {
+    public void simulate(ProgramStatement statement) throws SimulationException {
         int[] operands = statement.getOperands();
-        float in = FloatingPointRegisterFile.getFloatFromRegister(operands[1]);
-        if (Float.isNaN(in) || in > DataTypes.MAX_WORD_VALUE) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x10); // Set invalid flag
-            RegisterFile.updateRegister(operands[0], DataTypes.MAX_WORD_VALUE);
-        } else if (in < DataTypes.MIN_WORD_VALUE) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x10); // Set invalid flag
-            RegisterFile.updateRegister(operands[0], DataTypes.MIN_WORD_VALUE);
-        } else {
-            RegisterFile.updateRegister(operands[0], Math.round(in));
-        }
-
+        Environment e = new Environment();
+        e.mode = Floating.getRoundingMode(operands[2],statement);
+        Float32 in = new Float32(FloatingPointRegisterFile.getValue(operands[1]));
+        int out = jsoftfloat.operations.Conversions.convertToInt(in,e,false);
+        Floating.setfflags(e);
+        RegisterFile.updateRegister(operands[0],out);
     }
 }
 

--- a/src/rars/riscv/instructions/FDIVS.java
+++ b/src/rars/riscv/instructions/FDIVS.java
@@ -1,5 +1,7 @@
 package rars.riscv.instructions;
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
 import rars.riscv.hardware.ControlAndStatusRegisterFile;
 
 /*
@@ -34,8 +36,8 @@ public class FDIVS extends Floating {
         super("fdiv.s", "Floating DIVide: assigns f1 to f2 / f3", "0001100");
     }
 
-    public float compute(float f1, float f2) {
-        if (f2 == 0.0f) ControlAndStatusRegisterFile.orRegister("fcsr", 0x8); // Set Divide by zero flag
-        return f1 / f2;
+    @Override
+    public Float32 compute(Float32 f1, Float32 f2, Environment e) {
+        return jsoftfloat.operations.Arithmetic.division(f1,f2,e);
     }
 }

--- a/src/rars/riscv/instructions/FMADDS.java
+++ b/src/rars/riscv/instructions/FMADDS.java
@@ -27,12 +27,15 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FMADDS extends FusedFloat {
     public FMADDS() {
         super("fmadd.s f1, f2, f3, f4", "Fused Multiply Add: Assigns f2*f3+f4 to f1", "00");
     }
 
-    public float compute(float r1, float r2, float r3) {
-        return r1 * r2 + r3;
+    public Float32 compute(Float32 f1, Float32 f2, Float32 f3, Environment e){
+        return jsoftfloat.operations.Arithmetic.fusedMultiplyAdd(f1,f2,f3,e);
     }
 }

--- a/src/rars/riscv/instructions/FMAXS.java
+++ b/src/rars/riscv/instructions/FMAXS.java
@@ -27,13 +27,15 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FMAXS extends Floating {
     public FMAXS() {
         super("fmax.s", "Floating MAXimum: assigns f1 to the larger of f1 and f3", "0010100", "001");
     }
 
-    public float compute(float f1, float f2) {
-        // TODO: handle NaNs properly
-        return Math.max(f1, f2);
+    public Float32 compute(Float32 f1, Float32 f2, Environment env) {
+        return jsoftfloat.operations.Comparisons.maximumNumber(f1,f2,env);
     }
 }

--- a/src/rars/riscv/instructions/FMINS.java
+++ b/src/rars/riscv/instructions/FMINS.java
@@ -27,13 +27,15 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FMINS extends Floating {
     public FMINS() {
         super("fmin.s", "Floating MINimum: assigns f1 to the smaller of f1 and f3", "0010100", "000");
     }
 
-    public float compute(float f1, float f2) {
-        // TODO: handle NaNs properly
-        return Math.min(f1, f2);
+    public Float32 compute(Float32 f1, Float32 f2, Environment env) {
+        return jsoftfloat.operations.Comparisons.minimumNumber(f1,f2,env);
     }
 }

--- a/src/rars/riscv/instructions/FMSUBS.java
+++ b/src/rars/riscv/instructions/FMSUBS.java
@@ -27,12 +27,15 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FMSUBS extends FusedFloat {
     public FMSUBS() {
         super("fmsub.s f1, f2, f3, f4", "Fused Multiply Subatract: Assigns f2*f3-f4 to f1", "01");
     }
 
-    public float compute(float r1, float r2, float r3) {
-        return r1 * r2 - r3;
+    public Float32 compute(Float32 f1, Float32 f2, Float32 f3, Environment e){
+        return jsoftfloat.operations.Arithmetic.fusedMultiplyAdd(f1,f2,f3.negate(),e);
     }
 }

--- a/src/rars/riscv/instructions/FMULS.java
+++ b/src/rars/riscv/instructions/FMULS.java
@@ -27,12 +27,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FMULS extends Floating {
     public FMULS() {
         super("fmul.s", "Floating MULtiply: assigns f1 to f2 * f3", "0001000");
     }
 
-    public float compute(float f1, float f2) {
-        return f1 * f2;
+    @Override
+    public Float32 compute(Float32 f1, Float32 f2, Environment e) {
+        return jsoftfloat.operations.Arithmetic.multiplication(f1,f2,e);
     }
 }

--- a/src/rars/riscv/instructions/FNMADDS.java
+++ b/src/rars/riscv/instructions/FNMADDS.java
@@ -27,12 +27,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FNMADDS extends FusedFloat {
     public FNMADDS() {
         super("fnmadd.s f1, f2, f3, f4", "Fused Negate Multiply Add: Assigns -(f2*f3+f4) to f1", "11");
     }
 
-    public float compute(float r1, float r2, float r3) {
-        return -(r1 * r2 + r3);
+    public Float32 compute(Float32 f1, Float32 f2, Float32 f3, Environment e){
+        // TODO: rounding mode flipping
+        return jsoftfloat.operations.Arithmetic.fusedMultiplyAdd(f1,f2,f3,e).negate();
     }
 }

--- a/src/rars/riscv/instructions/FNMADDS.java
+++ b/src/rars/riscv/instructions/FNMADDS.java
@@ -36,7 +36,8 @@ public class FNMADDS extends FusedFloat {
     }
 
     public Float32 compute(Float32 f1, Float32 f2, Float32 f3, Environment e){
-        // TODO: rounding mode flipping
+        // TODO: test if this is the right behaviour
+        flipRounding(e);
         return jsoftfloat.operations.Arithmetic.fusedMultiplyAdd(f1,f2,f3,e).negate();
     }
 }

--- a/src/rars/riscv/instructions/FNMSUBS.java
+++ b/src/rars/riscv/instructions/FNMSUBS.java
@@ -27,12 +27,15 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FNMSUBS extends FusedFloat {
     public FNMSUBS() {
         super("fnmsub.s f1, f2, f3, f4", "Fused Negated Multiply Subatract: Assigns -(f2*f3-f4) to f1", "10");
     }
 
-    public float compute(float r1, float r2, float r3) {
-        return -(r1 * r2 - r3);
+    public Float32 compute(Float32 f1, Float32 f2, Float32 f3, Environment e){
+        return jsoftfloat.operations.Arithmetic.fusedMultiplyAdd(f1,f2,f3.negate(),e).negate();
     }
 }

--- a/src/rars/riscv/instructions/FNMSUBS.java
+++ b/src/rars/riscv/instructions/FNMSUBS.java
@@ -36,6 +36,7 @@ public class FNMSUBS extends FusedFloat {
     }
 
     public Float32 compute(Float32 f1, Float32 f2, Float32 f3, Environment e){
+        flipRounding(e);
         return jsoftfloat.operations.Arithmetic.fusedMultiplyAdd(f1,f2,f3.negate(),e).negate();
     }
 }

--- a/src/rars/riscv/instructions/FSQRTS.java
+++ b/src/rars/riscv/instructions/FSQRTS.java
@@ -3,6 +3,7 @@ package rars.riscv.instructions;
 import jsoftfloat.Environment;
 import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
+import rars.SimulationException;
 import rars.riscv.hardware.ControlAndStatusRegisterFile;
 import rars.riscv.hardware.FloatingPointRegisterFile;
 import rars.riscv.BasicInstruction;
@@ -41,9 +42,10 @@ public class FSQRTS extends BasicInstruction {
                 BasicInstructionFormat.I_FORMAT, "0101100 00000 sssss ttt fffff 1010011");
     }
 
-    public void simulate(ProgramStatement statement) {
+    public void simulate(ProgramStatement statement) throws SimulationException {
         int[] operands = statement.getOperands();
         Environment e = new Environment();
+        e.mode = Floating.getRoundingMode(operands[2],statement);
         Float32 result = jsoftfloat.operations.Arithmetic.squareRoot(new Float32(FloatingPointRegisterFile.getValue(operands[1])),e);
         Floating.setfflags(e);
         FloatingPointRegisterFile.updateRegister(operands[0],result.bits);

--- a/src/rars/riscv/instructions/FSQRTS.java
+++ b/src/rars/riscv/instructions/FSQRTS.java
@@ -1,5 +1,7 @@
 package rars.riscv.instructions;
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
 import rars.riscv.hardware.ControlAndStatusRegisterFile;
 import rars.riscv.hardware.FloatingPointRegisterFile;
@@ -41,13 +43,9 @@ public class FSQRTS extends BasicInstruction {
 
     public void simulate(ProgramStatement statement) {
         int[] operands = statement.getOperands();
-        float in = FloatingPointRegisterFile.getFloatFromRegister(operands[1]);
-        if (in < 0.0f) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x10); // Set invalid flag
-            FloatingPointRegisterFile.setRegisterToFloat(operands[0], Float.NaN);
-            return;
-        }
-        float result = (float) Math.sqrt(in);
-        FloatingPointRegisterFile.setRegisterToFloat(operands[0], result);
+        Environment e = new Environment();
+        Float32 result = jsoftfloat.operations.Arithmetic.squareRoot(new Float32(FloatingPointRegisterFile.getValue(operands[1])),e);
+        Floating.setfflags(e);
+        FloatingPointRegisterFile.updateRegister(operands[0],result.bits);
     }
 }

--- a/src/rars/riscv/instructions/FSUBS.java
+++ b/src/rars/riscv/instructions/FSUBS.java
@@ -27,12 +27,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (MIT license, http://www.opensource.org/licenses/mit-license.html)
  */
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
+
 public class FSUBS extends Floating {
     public FSUBS() {
         super("fsub.s", "Floating SUBtract: assigns f1 to f2 - f3", "0000100");
     }
 
-    public float compute(float f1, float f2) {
-        return f1 - f2;
+    @Override
+    public Float32 compute(Float32 f1, Float32 f2, Environment e) {
+        return jsoftfloat.operations.Arithmetic.subtraction(f1,f2,e);
     }
 }

--- a/src/rars/riscv/instructions/Floating.java
+++ b/src/rars/riscv/instructions/Floating.java
@@ -1,10 +1,13 @@
 package rars.riscv.instructions;
 
+import jsoftfloat.Flags;
+import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
 import rars.riscv.hardware.ControlAndStatusRegisterFile;
 import rars.riscv.hardware.FloatingPointRegisterFile;
 import rars.riscv.BasicInstruction;
 import rars.riscv.BasicInstructionFormat;
+import jsoftfloat.Environment;
 
 /*
 Copyright (c) 2017,  Benjamin Landers
@@ -49,27 +52,23 @@ public abstract class Floating extends BasicInstruction {
     protected Floating(String name, String description, String funct, String rm) {
         super(name + " f1, f2, f3", description, BasicInstructionFormat.R_FORMAT, funct + "ttttt sssss " + rm + "fffff 1010011");
     }
-
     public void simulate(ProgramStatement statement) {
         int[] operands = statement.getOperands();
-        float result = compute(FloatingPointRegisterFile.getFloatFromRegister(operands[1]),
-                FloatingPointRegisterFile.getFloatFromRegister(operands[2]));
-        if (Float.isNaN(result)) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x10); // Set invalid flag
-            if (!Floating.signallingNaN(result)) {
-                result = Float.NaN;
-            }
-        }
-        if (Float.isInfinite(result)) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x4); // Set Overflow flag
-        }
-        if (subnormal(result)) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x2); // Set Underflow flag
-        }
-        FloatingPointRegisterFile.setRegisterToFloat(operands[0], result);
+        Environment e = new Environment();
+        Float32 result = compute(new Float32(FloatingPointRegisterFile.getValue(operands[1])),new Float32(FloatingPointRegisterFile.getValue(operands[2])),e);
+        setfflags(e);
+        FloatingPointRegisterFile.updateRegister(operands[0], result.bits);
     }
 
-    public abstract float compute(float f1, float f2);
+    public static void setfflags(Environment e){
+        int fflags =(e.flags.contains(Flags.inexact)?1:0)+
+                (e.flags.contains(Flags.underflow)?2:0)+
+                (e.flags.contains(Flags.overflow)?4:0)+
+                (e.flags.contains(Flags.divByZero)?8:0)+
+                (e.flags.contains(Flags.invalid)?16:0);
+        if(fflags != 0) ControlAndStatusRegisterFile.orRegister("fflags",fflags);
+    }
+    public abstract Float32 compute(Float32 f1, Float32 f2, Environment e);
 
     public static boolean subnormal(float f) {
         int bits = Float.floatToRawIntBits(f);

--- a/src/rars/riscv/instructions/Floating.java
+++ b/src/rars/riscv/instructions/Floating.java
@@ -1,8 +1,10 @@
 package rars.riscv.instructions;
 
 import jsoftfloat.Flags;
+import jsoftfloat.RoundingMode;
 import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
+import rars.SimulationException;
 import rars.riscv.hardware.ControlAndStatusRegisterFile;
 import rars.riscv.hardware.FloatingPointRegisterFile;
 import rars.riscv.BasicInstruction;
@@ -52,9 +54,10 @@ public abstract class Floating extends BasicInstruction {
     protected Floating(String name, String description, String funct, String rm) {
         super(name + " f1, f2, f3", description, BasicInstructionFormat.R_FORMAT, funct + "ttttt sssss " + rm + "fffff 1010011");
     }
-    public void simulate(ProgramStatement statement) {
+    public void simulate(ProgramStatement statement) throws SimulationException{
         int[] operands = statement.getOperands();
         Environment e = new Environment();
+        e.mode = getRoundingMode(operands[3],statement);
         Float32 result = compute(new Float32(FloatingPointRegisterFile.getValue(operands[1])),new Float32(FloatingPointRegisterFile.getValue(operands[2])),e);
         setfflags(e);
         FloatingPointRegisterFile.updateRegister(operands[0], result.bits);
@@ -68,6 +71,27 @@ public abstract class Floating extends BasicInstruction {
                 (e.flags.contains(Flags.invalid)?16:0);
         if(fflags != 0) ControlAndStatusRegisterFile.orRegister("fflags",fflags);
     }
+
+    public static RoundingMode getRoundingMode(int RM, ProgramStatement statement) throws SimulationException {
+        int rm = RM;
+        int frm = ControlAndStatusRegisterFile.getValue("frm");
+        if (rm == 7) rm = frm;
+        switch (rm){
+            case 0: // RNE
+                return RoundingMode.even;
+            case 1: // RTZ
+                return RoundingMode.zero;
+            case 2: // RDN
+                return RoundingMode.min;
+            case 3: // RUP
+                return RoundingMode.max;
+            case 4: // RMM
+                return RoundingMode.away;
+            default:
+                throw new SimulationException(statement,"Invalid rounding mode. RM = " + RM +" and frm = " + frm);
+        }
+    }
+
     public abstract Float32 compute(Float32 f1, Float32 f2, Environment e);
 
     public static boolean subnormal(float f) {

--- a/src/rars/riscv/instructions/FusedFloat.java
+++ b/src/rars/riscv/instructions/FusedFloat.java
@@ -1,5 +1,7 @@
 package rars.riscv.instructions;
 
+import jsoftfloat.Environment;
+import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
 import rars.riscv.hardware.ControlAndStatusRegisterFile;
 import rars.riscv.hardware.FloatingPointRegisterFile;
@@ -44,19 +46,12 @@ public abstract class FusedFloat extends BasicInstruction {
 
     public void simulate(ProgramStatement statement) {
         int[] operands = statement.getOperands();
-        float result = compute(Float.intBitsToFloat(FloatingPointRegisterFile.getValue(operands[1])),
-                Float.intBitsToFloat(FloatingPointRegisterFile.getValue(operands[2])),
-                Float.intBitsToFloat(FloatingPointRegisterFile.getValue(operands[3])));
-        if (Float.isNaN(result)) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x10); // Set invalid flag
-        }
-        if (Float.isInfinite(result)) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x4); // Set Overflow flag
-        }
-        if (Floating.subnormal(result)) {
-            ControlAndStatusRegisterFile.orRegister("fcsr", 0x2); // Set Underflow flag
-        }
-        FloatingPointRegisterFile.setRegisterToFloat(operands[0], result);
+        Environment e = new Environment();
+        Float32 result = compute(new Float32(FloatingPointRegisterFile.getValue(operands[1])),
+                new Float32(FloatingPointRegisterFile.getValue(operands[2])),
+                new Float32(FloatingPointRegisterFile.getValue(operands[3])),e);
+        Floating.setfflags(e);
+        FloatingPointRegisterFile.updateRegister(operands[0],result.bits);
     }
 
     /**
@@ -65,5 +60,5 @@ public abstract class FusedFloat extends BasicInstruction {
      * @param r3 The third register
      * @return The value to store to the destination
      */
-    protected abstract float compute(float r1, float r2, float r3);
+    protected abstract Float32 compute(Float32 r1, Float32 r2, Float32 r3,Environment e);
 }

--- a/src/rars/riscv/instructions/FusedFloat.java
+++ b/src/rars/riscv/instructions/FusedFloat.java
@@ -1,8 +1,10 @@
 package rars.riscv.instructions;
 
 import jsoftfloat.Environment;
+import jsoftfloat.RoundingMode;
 import jsoftfloat.types.Float32;
 import rars.ProgramStatement;
+import rars.SimulationException;
 import rars.riscv.hardware.ControlAndStatusRegisterFile;
 import rars.riscv.hardware.FloatingPointRegisterFile;
 import rars.riscv.BasicInstruction;
@@ -44,9 +46,10 @@ public abstract class FusedFloat extends BasicInstruction {
                 "qqqqq 00 ttttt sssss " + "ppp" + " fffff 100" + op + "11");
     }
 
-    public void simulate(ProgramStatement statement) {
+    public void simulate(ProgramStatement statement) throws SimulationException {
         int[] operands = statement.getOperands();
         Environment e = new Environment();
+        e.mode = Floating.getRoundingMode(operands[4],statement);
         Float32 result = compute(new Float32(FloatingPointRegisterFile.getValue(operands[1])),
                 new Float32(FloatingPointRegisterFile.getValue(operands[2])),
                 new Float32(FloatingPointRegisterFile.getValue(operands[3])),e);
@@ -54,6 +57,13 @@ public abstract class FusedFloat extends BasicInstruction {
         FloatingPointRegisterFile.updateRegister(operands[0],result.bits);
     }
 
+    public static void flipRounding(Environment e){
+        if(e.mode == RoundingMode.max){
+            e.mode = RoundingMode.min;
+        }else if(e.mode == RoundingMode.min){
+            e.mode = RoundingMode.max;
+        }
+    }
     /**
      * @param r1 The first register
      * @param r2 The second register

--- a/test/riscv-tests/fadd.s
+++ b/test/riscv-tests/fadd.s
@@ -30,7 +30,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
- # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
     
   test_4: li gp, 4
  la a0, test_4_data 
@@ -43,7 +43,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-  # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
     
 
   test_5: li gp, 5
@@ -70,7 +70,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-  # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
     
   test_7: li gp, 7
  la a0, test_7_data 
@@ -83,7 +83,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-  # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
     
 
   test_8: li gp, 8
@@ -110,7 +110,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-  # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
     
   test_10: li gp, 10
  la a0, test_10_data 
@@ -123,7 +123,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-  # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
  
 
   # Is the canonical NaN generated for Inf - Inf?

--- a/test/riscv-tests/fcvt_w.s
+++ b/test/riscv-tests/fcvt_w.s
@@ -316,7 +316,7 @@
  test_8_data: .float -3e9
  .float 0.0
  .float 0.0
- .word 0x800000
+ .word 0x80000000
  
  test_9_data: .float 3e9
  .float 0.0

--- a/test/riscv-tests/fdiv.s
+++ b/test/riscv-tests/fdiv.s
@@ -17,7 +17,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-  # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
  
   test_3: li gp, 3
  la a0, test_3_data 
@@ -30,7 +30,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-# TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
  
   test_4: li gp, 4
  la a0, test_4_data 
@@ -56,7 +56,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-  # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
     
   test_6: li gp, 6
  la a0, test_6_data 
@@ -95,7 +95,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-  # TODO: inexact flag  bne a1, a2, fail
+ bne a1, a2, fail
     
 
   bne x0, gp, pass

--- a/test/riscv-tests/fmadd.s
+++ b/test/riscv-tests/fmadd.s
@@ -30,7 +30,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-   # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
  
   test_4: li gp, 4
  la a0, test_4_data 
@@ -70,7 +70,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-   # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
 
   test_7: li gp, 7
  la a0, test_7_data 
@@ -110,7 +110,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-   # TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
  
   test_10: li gp, 10
  la a0, test_10_data 
@@ -150,7 +150,7 @@
  fsflags a1, x0
  li a2, 1
  bne a0, a3, fail
-# TODO: inexact flag bne a1, a2, fail
+ bne a1, a2, fail
 
   test_13: li gp, 13
  la a0, test_13_data 


### PR DESCRIPTION
### Tradeoffs

This PR, if merged would solve #1. As far as I can tell it implements the floating point extension down to the flags, rounding modes, and treatment of NaNs. 

However, the compliance to the specification comes at a cost. The negatives I see are:
  1.  Floating point instructions take longer to execute
  2.  Inclusion of a dependency ([JSoftFloat](https://github.com/TheThirdOne/JSoftFloat))

I haven't done a rigorous benchmark, but it looks like floating point operations will take somewhere between 2x and 6x as long. 

I included JSoftFloat as a git submodule, so that comes with the cost of requiring new contributors to use `git clone --recursive` or use git submodule commands. 

### Request for Feedback

I am not sure how much proper treatment of floating point is actually a bonus for current users of RARS. I am also not sure if slower execution, and the dependency would be an issue. So I would like to ask if this is worth adding in.

I would like to make sure I get input from the universities I know are using RARS so I'll mention @TaylorZowtuk, @zacharyselk, @Obijuan, and @mvlamar.

### Mitigations

A configuration to enable fast and incorrect floating point should be possible, but I would have to see that people would actually want that before I implement it. I'll try to get some solid metrics so people can make an educated decision about whether they would want this option.

There may be a better way to include the dependency that would be more user friendly. I am open to suggestions on this. I am unfamiliar with build systems for Java so @jgbcode might be able to offer a good solution using maven.

 
