### PR TITLE
Change help text to display correct addresses

### DIFF
--- a/src/rars/tools/DigitalLabSim.java
+++ b/src/rars/tools/DigitalLabSim.java
@@ -2,6 +2,7 @@ package rars.tools;
 
 import rars.Globals;
 import rars.riscv.hardware.*;
+import rars.util.Binary;
 
 import javax.swing.*;
 import java.awt.*;
@@ -129,12 +130,12 @@ public class DigitalLabSim extends AbstractToolAndApplication {
         final String helpContent =
                 " This tool is composed of 3 parts : two seven-segment displays, an hexadecimal keyboard and counter \n" +
                         "Seven segment display\n" +
-                        " Byte value at address 0xFFFF0010 : command right seven segment display \n " +
-                        " Byte value at address 0xFFFF0011 : command left seven segment display \n " +
+                        " Byte value at address " + Binary.intToHexString(IN_ADRESS_DISPLAY_1) + " : command right seven segment display \n " +
+                        " Byte value at address " + Binary.intToHexString(IN_ADRESS_DISPLAY_2) + " : command left seven segment display \n " +
                         " Each bit of these two bytes are connected to segments (bit 0 for a segment, 1 for b segment and 7 for point \n \n" +
                         "Hexadecimal keyboard\n" +
-                        " Byte value at address 0xFFFF0012 : command row number of hexadecimal keyboard (bit 0 to 3) and enable keyboard interrupt (bit 7) \n" +
-                        " Byte value at address 0xFFFF0014 : receive row and column of the key pressed, 0 if not key pressed \n" +
+                        " Byte value at address " + Binary.intToHexString(IN_ADRESS_HEXA_KEYBOARD) + " : command row number of hexadecimal keyboard (bit 0 to 3) and enable keyboard interrupt (bit 7) \n" +
+                        " Byte value at address " + Binary.intToHexString(OUT_ADRESS_HEXA_KEYBOARD) + " : receive row and column of the key pressed, 0 if not key pressed \n" +
                         " The program has to scan, one by one, each row (send 1,2,4,8...)" +
                         " and then observe if a key is pressed (that mean byte value at adresse 0xFFFF0014 is different from zero). " +
                         " This byte value is composed of row number (4 left bits) and column number (4 right bits)" +
@@ -142,7 +143,7 @@ public class DigitalLabSim extends AbstractToolAndApplication {
                         " For exemple key number 2 return 0x41, that mean the key is on column 3 and row 1. \n" +
                         " If keyboard interruption is enable, an external interrupt is started with value 0x00000200\n \n" +
                         "Counter\n" +
-                        " Byte value at address 0xFFFF0013 : If one bit of this byte is set, the counter interruption is enabled.\n" +
+                        " Byte value at address " + Binary.intToHexString(IN_ADRESS_COUNTER) + " : If one bit of this byte is set, the counter interruption is enabled.\n" +
                         " If counter interruption is enable, every 30 instructions, a timer interrupt is started with value 0x00000100.\n" +
                         "   (contributed by Didier Teifreto, dteifreto@lifc.univ-fcomte.fr)";
         JButton help = new JButton("Help");


### PR DESCRIPTION
While the Data Lab Sim module auto adjusts with MMIO address range, the help text address values are not updated accordingly. This fixes the help text to show the updated address values.