### PR TITLE
Initial fixes for IO Piping

### DIFF
--- a/src/rars/api/Program.java
+++ b/src/rars/api/Program.java
@@ -143,12 +143,15 @@ public class Program {
         Memory.swapInstance(tmpMem);
 
         // To capture the IO we need to replace stdin and friends
-        fds = new SystemIO.Data(true);
-        if(STDIN != null) {
-            fds.streams[0] = new ByteArrayInputStream(STDIN.getBytes());
-            fds.streams[1] = stdout = new ByteArrayOutputStream();
-            fds.streams[2] = stderr = new ByteArrayOutputStream();
-        }
+	if (STDIN!=null){
+		stdout=new ByteArrayOutputStream();
+		stderr=new ByteArrayOutputStream();
+		fds=new SystemIO.Data(
+				new ByteArrayInputStream(STDIN.getBytes()),stdout,stderr
+			);
+	} else {
+		fds=new SystemIO.Data(true);
+	}
     }
 
     /**

--- a/src/rars/tools/InstructionMemoryDump.java
+++ b/src/rars/tools/InstructionMemoryDump.java
@@ -45,7 +45,7 @@
  * The file you generate has one line per datum. The four kinds of
  *   data you will see in the trace are:
  *
- * ‘I”: The address of an access into instruction memory
+ * ‘I': The address of an access into instruction memory
  * ‘i’: A 32-bit RISC-V instruction (the trace first dumps the address then
  *      the instruction)
  * ‘L’: The address of a memory load into data memory


### PR DESCRIPTION
I added IO buffers to ```Data``` and ```FileIOData``` so that they can be set in ```swapData```, as you requested in issue #118. Also added another constructor to ```Data``` to make it easier to set different IO buffers. Modified SystemIO to work with the new buffers.

Changed InstructionMemoryDump.java only because there was a character that was not recognized by the compiler.
```
src\rars\tools\InstructionMemoryDump.java:48: error: unmappable character (0x9D) for encoding windows-1252
 * ‘I▒?: The address of an access into instruction memory
         ^
```