### PR TITLE
Open relative files from executing program path

### DIFF
--- a/src/Settings.properties
+++ b/src/Settings.properties
@@ -30,4 +30,4 @@ DataSegmentHighlightBackground = 0x0099ccff
 DataSegmentHighlightForeground = 0
 RegisterHighlightBackground = 0x0099cc55
 RegisterHighlightForeground = 0
-
+DeriveCurrentDirectory = false

--- a/src/rars/Settings.java
+++ b/src/rars/Settings.java
@@ -153,7 +153,12 @@ public class Settings extends Observable {
         /**
          * Flag to determine whether a program uses rv64i instead of rv32i
          */
-        RV64_ENABLED("rv64Enabled", false);;
+        RV64_ENABLED("rv64Enabled", false),
+        /**
+         * Flag to determine whether to calculate relative paths from the current working directory
+         * or from the RARS executable path.
+        */
+        DERIVE_CURRENT_WORKING_DIRECTORY("DeriveCurrentWorkingDirectory", false);
 
         // TODO: add option for turning off user trap handling and interrupts
         private String name;

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -377,9 +377,10 @@ public class SystemIO {
             return -1;
         }   // fileErrorString would have been set
 
-        String parent = new File(Globals.program.getFilename()).getParent();
         File filepath = new File(filename);
-        if (!filepath.isAbsolute()) {
+        if (!filepath.isAbsolute() && Globals.program != null && Globals.getSettings()
+                .getBooleanSetting(Settings.Bool.DERIVE_CURRENT_WORKING_DIRECTORY)) {
+            String parent = new File(Globals.program.getFilename()).getParent();
             filepath = new File(parent, filename);
         }
         if (flags == O_RDONLY) // Open for reading only

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -377,12 +377,16 @@ public class SystemIO {
             return -1;
         }   // fileErrorString would have been set
 
-
+        String parent = new File(Globals.program.getFilename()).getParent();
+        File filepath = new File(filename);
+        if (!filepath.isAbsolute()) {
+            filepath = new File(parent, filename);
+        }
         if (flags == O_RDONLY) // Open for reading only
         {
             try {
                 // Set up input stream from disk file
-                inputStream = new FileInputStream(filename);
+                inputStream = new FileInputStream(filepath);
                 FileIOData.setStreamInUse(fdToUse, inputStream); // Save stream for later use
             } catch (FileNotFoundException e) {
                 fileErrorString = "File " + filename + " not found, open for input.";
@@ -392,7 +396,7 @@ public class SystemIO {
         {
             // Set up output stream to disk file
             try {
-                outputStream = new FileOutputStream(filename, ((flags & O_APPEND) != 0));
+                outputStream = new FileOutputStream(filepath, ((flags & O_APPEND) != 0));
                 FileIOData.setStreamInUse(fdToUse, outputStream); // Save stream for later use
             } catch (FileNotFoundException e) {
                 fileErrorString = "File " + filename + " not found, open for output.";

--- a/src/rars/venus/VenusUI.java
+++ b/src/rars/venus/VenusUI.java
@@ -84,7 +84,7 @@ public class VenusUI extends JFrame {
     private JMenuItem runGo, runStep, runBackstep, runReset, runAssemble, runStop, runPause, runClearBreakpoints, runToggleBreakpoints;
     private JCheckBoxMenuItem settingsLabel, settingsPopupInput, settingsValueDisplayBase, settingsAddressDisplayBase,
             settingsExtended, settingsAssembleOnOpen, settingsAssembleAll, settingsAssembleOpen, settingsWarningsAreErrors,
-            settingsStartAtMain, settingsProgramArguments, settingsSelfModifyingCode,settingsRV64;
+            settingsStartAtMain, settingsProgramArguments, settingsSelfModifyingCode, settingsRV64, settingsDeriveCurrentWorkingDirectory;
     private JMenuItem settingsExceptionHandler, settingsEditor, settingsHighlighting, settingsMemoryConfiguration;
     private JMenuItem helpHelp, helpAbout;
 
@@ -108,8 +108,8 @@ public class VenusUI extends JFrame {
     private Action settingsLabelAction, settingsPopupInputAction, settingsValueDisplayBaseAction, settingsAddressDisplayBaseAction,
             settingsExtendedAction, settingsAssembleOnOpenAction, settingsAssembleOpenAction, settingsAssembleAllAction,
             settingsWarningsAreErrorsAction, settingsStartAtMainAction, settingsProgramArgumentsAction,
-            settingsExceptionHandlerAction, settingsEditorAction,
-            settingsHighlightingAction, settingsMemoryConfigurationAction, settingsSelfModifyingCodeAction,settingsRV64Action;
+            settingsExceptionHandlerAction, settingsEditorAction, settingsHighlightingAction, settingsMemoryConfigurationAction,
+            settingsSelfModifyingCodeAction, settingsRV64Action, settingsDeriveCurrentWorkingDirectoryAction;
     private Action helpHelpAction, helpAboutAction;
 
 
@@ -461,7 +461,9 @@ public class VenusUI extends JFrame {
                     csrTab.updateRegisters();
                 }
             };
-
+            settingsDeriveCurrentWorkingDirectoryAction = new SettingsAction("Derive current working directory",
+                    "If set, the working directory is derived from the main file instead of the RARS executable directory.",
+                    Settings.Bool.DERIVE_CURRENT_WORKING_DIRECTORY);
 
 
             settingsEditorAction = new SettingsEditorAction("Editor...", null,
@@ -615,6 +617,8 @@ public class VenusUI extends JFrame {
         settingsSelfModifyingCode.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.SELF_MODIFYING_CODE_ENABLED));
         settingsRV64 = new JCheckBoxMenuItem(settingsRV64Action);
         settingsRV64.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.RV64_ENABLED));
+        settingsDeriveCurrentWorkingDirectory = new JCheckBoxMenuItem(settingsDeriveCurrentWorkingDirectoryAction);
+        settingsDeriveCurrentWorkingDirectory.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.DERIVE_CURRENT_WORKING_DIRECTORY));
         settingsAssembleOnOpen = new JCheckBoxMenuItem(settingsAssembleOnOpenAction);
         settingsAssembleOnOpen.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.ASSEMBLE_ON_OPEN));
         settingsAssembleAll = new JCheckBoxMenuItem(settingsAssembleAllAction);
@@ -643,6 +647,7 @@ public class VenusUI extends JFrame {
         settings.add(settingsAssembleOpen);
         settings.add(settingsWarningsAreErrors);
         settings.add(settingsStartAtMain);
+        settings.add(settingsDeriveCurrentWorkingDirectory);
         settings.addSeparator();
         settings.add(settingsExtended);
         settings.add(settingsSelfModifyingCode);


### PR DESCRIPTION
When giving a relative file path, RARS will look from the path of the RISC-V program, not the from the RARS path. This is more intuitive. Absolute file paths remain unaffected.