### PR TITLE
Fixed build-jar.sh to work with MacOS

### DIFF
--- a/build-jar.sh
+++ b/build-jar.sh
@@ -1,7 +1,12 @@
+#!/bin/bash
 if git submodule status | grep \( > /dev/null ; then 
     mkdir -p build
     find src -name "*.java" | xargs javac -d build
-    find src -type f -not -name "*.java" -exec cp --parents {} build \;
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        find src -type f -not -name "*.java" -exec rsync -R {} build \;
+    else
+        find src -type f -not -name "*.java" -exec cp --parents {} build \;
+    fi
     cp -rf build/src/* build
     rm -r build/src
     cp README.md License.txt build


### PR DESCRIPTION
The issue was that in MacOS `cp --parents` doesn't exist. The solution was to use the `rsync -R` command which comes standard on MacOS. [Stack Overflow reference](https://stackoverflow.com/a/13855290/11337553)

The script now checks if the OS is Darwin (line 5) and executes the proper copy command alternative (line 6). Otherwise, it runs the original which works fine for other operating systems. 

Fixes #127