### PR TITLE
Make table row height respect font size

### DIFF
--- a/src/rars/Settings.java
+++ b/src/rars/Settings.java
@@ -896,10 +896,8 @@ public class Settings extends Observable {
             saveFontSetting(fontSettingPosition, fontStyleSettingsKeys, fontStyleSettingsValues);
             saveFontSetting(fontSettingPosition, fontSizeSettingsKeys, fontSizeSettingsValues);
         }
-        if (fontSettingPosition == EDITOR_FONT) {
-            setChanged();
-            notifyObservers();
-        }
+        setChanged();
+        notifyObservers();
     }
 
 

--- a/src/rars/venus/DataSegmentWindow.java
+++ b/src/rars/venus/DataSegmentWindow.java
@@ -176,7 +176,6 @@ public class DataSegmentWindow extends JInternalFrame implements Observer {
         contentPane.add(features, BorderLayout.SOUTH);
     }
 
-
     public void updateBaseAddressComboBox() {
         displayBaseAddressArray[EXTERN_BASE_ADDRESS_INDEX] = Memory.externBaseAddress;
         displayBaseAddressArray[GLOBAL_POINTER_ADDRESS_INDEX] = -1; /*Memory.globalPointer*/
@@ -431,6 +430,7 @@ public class DataSegmentWindow extends JInternalFrame implements Observer {
             names[i] = getHeaderStringForColumn(i, addressBase);
         }
         dataTable = new MyTippedJTable(new DataTableModel(dataData, names));
+        updateRowHeight();
         // Do not allow user to re-order columns; column order corresponds to MIPS memory order
         dataTable.getTableHeader().setReorderingAllowed(false);
         dataTable.setRowSelectionAllowed(false);
@@ -827,6 +827,8 @@ public class DataSegmentWindow extends JInternalFrame implements Observer {
             // Suspended work in progress. Intended to disable combobox item for text segment. DPS 9-July-2013.
             //baseAddressSelector.getModel().getElementAt(TEXT_BASE_ADDRESS_INDEX)
             //*.setEnabled(settings.getBooleanSetting(Settings.SELF_MODIFYING_CODE_ENABLED));
+
+            updateRowHeight();
         } else if (obj instanceof MemoryAccessNotice) {            // NOTE: observable != Memory.getInstance() because Memory class delegates notification duty.
             MemoryAccessNotice access = (MemoryAccessNotice) obj;
             if (access.getAccessType() == AccessNotice.WRITE) {
@@ -836,6 +838,25 @@ public class DataSegmentWindow extends JInternalFrame implements Observer {
                 this.highlightCellForAddress(address);
             }
         }
+    }
+
+    private void updateRowHeight() {
+        if (dataTable == null) {
+            return;
+        }
+        Font possibleFonts[] = {
+            settings.getFontByPosition(Settings.DATASEGMENT_HIGHLIGHT_FONT),
+            settings.getFontByPosition(Settings.EVEN_ROW_FONT),
+            settings.getFontByPosition(Settings.ODD_ROW_FONT),
+        };
+        int maxHeight = 0;
+        for (int i = 0; i < possibleFonts.length; i++) {
+            int height = getFontMetrics(possibleFonts[i]).getHeight();
+            if (height > maxHeight) {
+                maxHeight = height;
+            }
+        }
+        dataTable.setRowHeight(maxHeight);
     }
 
 

--- a/src/rars/venus/TextSegmentWindow.java
+++ b/src/rars/venus/TextSegmentWindow.java
@@ -646,6 +646,9 @@ public class TextSegmentWindow extends JInternalFrame implements Observer {
 
 
     private void updateRowHeight() {
+        if (table == null) {
+            return;
+        }
         Font possibleFonts[] = {
             Globals.getSettings().getFontByPosition(Settings.TEXTSEGMENT_HIGHLIGHT_FONT),
             Globals.getSettings().getFontByPosition(Settings.EVEN_ROW_FONT),

--- a/src/rars/venus/TextSegmentWindow.java
+++ b/src/rars/venus/TextSegmentWindow.java
@@ -158,18 +158,10 @@ public class TextSegmentWindow extends JInternalFrame implements Observer {
             tableModel.fireTableDataChanged();// initialize listener
         }
         table = new MyTippedJTable(tableModel);
+        updateRowHeight();
 
         // prevents cells in row from being highlighted when user clicks on breakpoint checkbox
         table.setRowSelectionAllowed(false);
-
-        table.getColumnModel().getColumn(BREAK_COLUMN).setMinWidth(40);
-        table.getColumnModel().getColumn(ADDRESS_COLUMN).setMinWidth(80);
-        table.getColumnModel().getColumn(CODE_COLUMN).setMinWidth(80);
-
-        table.getColumnModel().getColumn(BREAK_COLUMN).setMaxWidth(50);
-        table.getColumnModel().getColumn(ADDRESS_COLUMN).setMaxWidth(90);
-        table.getColumnModel().getColumn(CODE_COLUMN).setMaxWidth(90);
-        table.getColumnModel().getColumn(BASIC_COLUMN).setMaxWidth(200);
 
         table.getColumnModel().getColumn(BREAK_COLUMN).setPreferredWidth(40);
         table.getColumnModel().getColumn(ADDRESS_COLUMN).setPreferredWidth(80);
@@ -322,6 +314,7 @@ public class TextSegmentWindow extends JInternalFrame implements Observer {
             if (Globals.getSettings().getBooleanSetting(Settings.Bool.SELF_MODIFYING_CODE_ENABLED)) {
                 addAsTextSegmentObserver();
             }
+            updateRowHeight();
         } else if (obj instanceof MemoryAccessNotice) {
             // NOTE: observable != Memory.getInstance() because Memory class delegates notification duty.
             // This will occur only if running program has written to text segment (self-modifying code)
@@ -649,6 +642,23 @@ public class TextSegmentWindow extends JInternalFrame implements Observer {
             //return addressRow;// if address not in map, do nothing.
         }
         return addressRow;
+    }
+
+
+    private void updateRowHeight() {
+        Font possibleFonts[] = {
+            Globals.getSettings().getFontByPosition(Settings.TEXTSEGMENT_HIGHLIGHT_FONT),
+            Globals.getSettings().getFontByPosition(Settings.EVEN_ROW_FONT),
+            Globals.getSettings().getFontByPosition(Settings.ODD_ROW_FONT),
+        };
+        int maxHeight = 0;
+        for (int i = 0; i < possibleFonts.length; i++) {
+            int height = getFontMetrics(possibleFonts[i]).getHeight();
+            if (height > maxHeight) {
+                maxHeight = height;
+            }
+        }
+        table.setRowHeight(maxHeight);
     }
 
 

--- a/src/rars/venus/registers/RegisterBlockWindow.java
+++ b/src/rars/venus/registers/RegisterBlockWindow.java
@@ -75,11 +75,13 @@ public abstract class RegisterBlockWindow extends JPanel implements Observer {
     public RegisterBlockWindow(Register[] registers, String[] registerDescriptions, String valueTip) {
         Simulator.getInstance().addObserver(this);
         settings = Globals.getSettings();
+        settings.addObserver(this);
         this.registers = registers;
         clearHighlighting();
         table = new MyTippedJTable(new RegTableModel(setupWindow()), registerDescriptions,
                 new String[]{"Each register has a tool tip describing its usage convention", "Corresponding register number", valueTip}) {
         };
+        updateRowHeight();
         table.getColumnModel().getColumn(NAME_COLUMN).setPreferredWidth(50);
         table.getColumnModel().getColumn(NUMBER_COLUMN).setPreferredWidth(25);
         table.getColumnModel().getColumn(VALUE_COLUMN).setPreferredWidth(60);
@@ -195,6 +197,8 @@ public abstract class RegisterBlockWindow extends JPanel implements Observer {
                 // Simulated MIPS execution stops.  Stop responding.
                 endObserving();
             }
+        } else if (observable == settings) {
+            updateRowHeight();
         } else if (obj instanceof RegisterAccessNotice) {
             // NOTE: each register is a separate Observable
             RegisterAccessNotice access = (RegisterAccessNotice) obj;
@@ -206,6 +210,22 @@ public abstract class RegisterBlockWindow extends JPanel implements Observer {
                 Globals.getGui().getRegistersPane().setSelectedComponent(this);
             }
         }
+    }
+
+    private void updateRowHeight() {
+        Font possibleFonts[] = {
+            settings.getFontByPosition(Settings.REGISTER_HIGHLIGHT_FONT),
+            settings.getFontByPosition(Settings.EVEN_ROW_FONT),
+            settings.getFontByPosition(Settings.ODD_ROW_FONT),
+        };
+        int maxHeight = 0;
+        for (int i = 0; i < possibleFonts.length; i++) {
+            int height = getFontMetrics(possibleFonts[i]).getHeight();
+            if (height > maxHeight) {
+                maxHeight = height;
+            }
+        }
+        table.setRowHeight(maxHeight);
     }
 
 


### PR DESCRIPTION
Previously any change of font settings didn't affect the height of table cells. This pull request fixes that.
Solves issue #146. 
Nevertheless there are reasons to provide additional font settings for Address and Code columns of segment views as they aren't affected right now.