### PR TITLE
Prevent NullPointerException when reading from /dev/null

### DIFF
--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -99,6 +99,8 @@ public class SystemIO {
         if (Globals.getGui() == null) {
             try {
                 input = getInputReader().readLine();
+                if (input == null)
+                    input = "";
             } catch (IOException e) {
             }
         } else {


### PR DESCRIPTION
When running something like
```
li a7, 12
ecall
```
in this manner:
`rars nc this_program.s < /dev/null`
got Exception in thread "main" java.lang.NullPointerException

The problem is [here](https://github.com/TheThirdOne/rars/blob/533d3c006113237199988e4a7d98441ad1ab36df/src/rars/util/SystemIO.java#L101l):  `.readLine()` just returns null. This fixes it.