### PR TITLE
Fix floating point comparison

### DIFF
--- a/src/PseudoOps.txt
+++ b/src/PseudoOps.txt
@@ -271,7 +271,7 @@ lw t1,%lo(label)(t2)  ;lw RG1,LL4(RG7)  ;#Load from Address
 flw f1,%lo(label)(t2) ;flw RG1,LL4(RG7) ;#Load from Address
 fld f1,%lo(label)(t2) ;fld RG1,LL4(RG7) ;#Load from Address
 
-fgt.s t1, f2, f3      ;fle.s RG1, RG3, RG2 ;#Floating Greater Than: if f2 > f3, set t1 to 1, else set t1 to 0
-fge.s t1, f2, f3      ;flt.s RG1, RG3, RG2 ;#Floating Greater Than or Equal: if f2 >= f3, set t1 to 1, else set t1 to 0
-fgt.d t1, f2, f3      ;fle.d RG1, RG3, RG2 ;#Floating Greater Than (64 bit): if f2 > f3, set t1 to 1, else set t1 to 0
-fge.d t1, f2, f3      ;flt.d RG1, RG3, RG2 ;#Floating Greater Than or Equal (64 bit): if f2 >= f3, set t1 to 1, else set t1 to 0
+fgt.s t1, f2, f3      ;flt.s RG1, RG3, RG2 ;#Floating Greater Than: if f2 > f3, set t1 to 1, else set t1 to 0
+fge.s t1, f2, f3      ;fle.s RG1, RG3, RG2 ;#Floating Greater Than or Equal: if f2 >= f3, set t1 to 1, else set t1 to 0
+fgt.d t1, f2, f3      ;flt.d RG1, RG3, RG2 ;#Floating Greater Than (64 bit): if f2 > f3, set t1 to 1, else set t1 to 0
+fge.d t1, f2, f3      ;fle.d RG1, RG3, RG2 ;#Floating Greater Than or Equal (64 bit): if f2 >= f3, set t1 to 1, else set t1 to 0


### PR DESCRIPTION
After #131, the `fgt.* t0, t1, t2` and `fge.* t0, t1, t2` pseudo-instructions are defined, respectively, as `fle.* t0, t2, t1` and `flt.* t0, t2, t1`. 
However, they should be defined as `flt.* t0, t2, t1` and `fle.* t0, t2, t1`, as `x > y <=> y < x` and `x >= y iff y <= x`.