### PR TITLE
Added file open support

### DIFF
--- a/src/help/Command.html
+++ b/src/help/Command.html
@@ -32,6 +32,7 @@ The format for running RARS from a command line is:<br><br>
 <tr><td width=40 align="right"><tt>dump</tt></td><td>dump memory contents to file.  
 Option has 3 arguments, e.g. <tt>dump &lt;segment&gt; &lt;format&gt; &lt;file&gt;</tt>.  Current supported segments are <tt>.text</tt>
 and <tt>.data</tt>.  Also supports an address range (see <i>m-n</i> below).  Current supported dump formats are <tt>Binary</tt>, <tt>HexText</tt>, <tt>BinaryText</tt>, <tt>AsciiText</tt>.  See examples below.</td><td>3.4</td></tr>
+<tr><td width=40 align="right"><tt>g</tt></td><td>force GUI mode</td><td>1.6</td></tr>
 <tr><td width=40 align="right"><tt>hex</tt></td><td>display memory or register contents in hexadecimal - this is the default. (alternatives are <tt>ascii</tt> and <tt>dec</tt>)</td><td>2.2</td></tr>
 <tr><td width=40 align="right"><tt>h</tt></td><td>display this help.  Use this option by itself and with no filename.</td><td>1.0</td></tr>
 <tr><td width=40 align="right"><tt>ic</tt></td><td>display instruction count; the number of basic instructions 'executed'</td><td>4.3</td></tr>

--- a/src/rars/Globals.java
+++ b/src/rars/Globals.java
@@ -164,11 +164,11 @@ public class Globals {
      * Method called once upon system initialization to create the global data structures.
      **/
 
-    public static void initialize(boolean gui) {
+    public static void initialize() {
         if (!initialized) {
             memory = Memory.getInstance();  //clients can use Memory.getInstance instead of Globals.memory
             symbolTable = new SymbolTable("global");
-            settings = new Settings(gui);
+            settings = new Settings();
             instructionSet = new InstructionSet();
             instructionSet.populate();
             initialized = true;

--- a/src/rars/Launch.java
+++ b/src/rars/Launch.java
@@ -134,9 +134,8 @@ public class Launch {
         new Launch(args);
     }
     private Launch(String[] args) {
-        boolean gui = (args.length == 0);
-        Globals.initialize(gui);
-        if (gui) {
+        Globals.initialize();
+        if (args.length == 0) {
             launchIDE();
         } else { // running from command line.
             // assure command mode works in headless environment (generates exception if not)

--- a/src/rars/Settings.java
+++ b/src/rars/Settings.java
@@ -401,20 +401,8 @@ public class Settings extends Observable {
      * based on defaults stored in Settings.properties file.  If file problems, will set based
      * on defaults stored in this class.
      */
+
     public Settings() {
-        this(true);
-    }
-
-    /**
-     * Create Settings object and set to saved values.  If saved values not found, will set
-     * based on defaults stored in Settings.properties file.  If file problems, will set based
-     * on defaults stored in this class.
-     *
-     * @param gui true if running the graphical IDE, false if running from command line.
-     *            Ignored as of release 3.6 but retained for compatability.
-     */
-
-    public Settings(boolean gui) {
         booleanSettingsValues = new HashMap<>();
         stringSettingsValues = new String[stringSettingsKeys.length];
         fontFamilySettingsValues = new String[fontFamilySettingsKeys.length];
@@ -450,11 +438,8 @@ public class Settings extends Observable {
 
     /**
      * Reset settings to default values, as described in the constructor comments.
-     *
-     * @param gui true if running from GUI IDE and false if running from command mode.
-     *            Ignored as of release 3.6 but retained for compatibility.
      */
-    public void reset(boolean gui) {
+    public void reset() {
         initialize();
     }
 

--- a/src/rars/api/Program.java
+++ b/src/rars/api/Program.java
@@ -53,7 +53,7 @@ public class Program {
     }
 
     public Program(Options set){
-        Globals.initialize(false);
+        Globals.initialize();
         this.set = set;
         code = new RISCVprogram();
         assembled = new Memory();

--- a/src/rars/extras/Documentation.java
+++ b/src/rars/extras/Documentation.java
@@ -19,7 +19,7 @@ import java.util.HashSet;
 public class Documentation {
 
     public static void main(String[] args){
-        Globals.initialize(false);
+        Globals.initialize();
         System.out.println(createDirectiveMarkdown());
         System.out.println(createSyscallMarkdown());
         System.out.println(createInstructionMarkdown(BasicInstruction.class));

--- a/src/rars/tools/AbstractToolAndApplication.java
+++ b/src/rars/tools/AbstractToolAndApplication.java
@@ -149,7 +149,7 @@ public abstract class AbstractToolAndApplication extends JFrame implements Tool,
         theWindow = this;
         this.isBeingUsedAsATool = false;
         this.setTitle(this.title);
-        rars.Globals.initialize(true);
+        rars.Globals.initialize();
         // assure the dialog goes away if user clicks the X
         this.addWindowListener(
                 new WindowAdapter() {

--- a/src/rars/venus/Editor.java
+++ b/src/rars/venus/Editor.java
@@ -1,6 +1,7 @@
 package rars.venus;
 
 import java.io.File;
+import java.util.ArrayList;
  
  /*
 Copyright (c) 2003-2007,  Pete Sanderson and Kenneth Vollmar
@@ -243,6 +244,21 @@ public class Editor {
         return editTabbedPane.openFile();
     }
 
+    /**
+     * Open files in new tabs.
+     * @param paths File paths to open
+     * @return true if succeeded, else false.
+     */
+    public boolean open(ArrayList<String> paths) {
+        for (String path : paths) {
+            File file = new File(path);
+            if (!editTabbedPane.openFile(file)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /**
      * Called by several of the Action objects when there is potential

--- a/src/rars/venus/VenusUI.java
+++ b/src/rars/venus/VenusUI.java
@@ -143,7 +143,7 @@ public class VenusUI extends JFrame {
         // I want to keep it large, with enough room for user to get handles
         //this.setSize((int)(screenWidth*.8),(int)(screenHeight*.8));
 
-        Globals.initialize(true);
+        Globals.initialize();
 
         //  image courtesy of NASA/JPL.
         URL im = this.getClass().getResource(Globals.imagesPath + "RISC-V.png");

--- a/src/rars/venus/VenusUI.java
+++ b/src/rars/venus/VenusUI.java
@@ -16,6 +16,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 import java.net.URL;
+import java.util.ArrayList;
 
 /*
 Copyright (c) 2003-2013,  Pete Sanderson and Kenneth Vollmar
@@ -116,11 +117,12 @@ public class VenusUI extends JFrame {
     /**
      * Constructor for the Class. Sets up a window object for the UI
      *
-     * @param s Name of the window to be created.
+     * @param name Name of the window to be created.
+     * @param paths File paths to open width
      **/
 
-    public VenusUI(String s) {
-        super(s);
+    public VenusUI(String name, ArrayList<String> paths) {
+        super(name);
         mainUI = this;
         Globals.setGui(this);
         this.editor = new Editor(this);
@@ -238,6 +240,12 @@ public class VenusUI extends JFrame {
 
         this.pack();
         this.setVisible(true);
+
+        // Open files
+        if (!this.editor.open(paths)) {
+            System.out.println("Internal Error: could not open files" + String.join(", ", paths));
+            System.exit(1);
+        }
     }
 
 

--- a/test/Test.java
+++ b/test/Test.java
@@ -10,7 +10,7 @@ import java.util.Iterator;
 
 public class Test {
     public static void main(String[] args){
-        Globals.initialize(false);
+        Globals.initialize();
         Globals.getSettings().setBooleanSettingNonPersistent(Settings.Bool.RV64_ENABLED,false);
         InstructionSet.rv64 = false;
         Globals.instructionSet.populate();


### PR DESCRIPTION
This pull request adds:
* The ability to launch RARS (in GUI mode) with a file open as the default tab via passing the file path as an argument (This is necessary for desktop integration since it allows one to simply double-click an assembly file to open it in RARS)
* A `c` command line switch to force RARS to launch in CLI mode (In the event anyone is calling RARS with a file path and no other arguments, but don't want to start the GUI, they should use this flag)