### PR TITLE
Encoding fix

### DIFF
--- a/build-jar.sh
+++ b/build-jar.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if git submodule status | grep \( > /dev/null ; then 
     mkdir -p build
-    find src -name "*.java" | xargs javac -d build
+    find src -name "*.java" | xargs javac -encoding utf-8 -d build
     if [[ "$OSTYPE" == "darwin"* ]]; then
         find src -type f -not -name "*.java" -exec rsync -R {} build \;
     else

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
-javac -cp rars.jar test/Test.java
-java -cp test:rars.jar Test
+javac -encoding utf-8 -cp rars.jar test/Test.java
+if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+	java -Dfile.encoding=UTF8 -cp "test;rars.jar" Test
+else
+	java -Dfile.encoding=UTF8 -cp test:rars.jar Test
+fi
 rm test/Test.class


### PR DESCRIPTION
Force use of UTF-8 encoding during compilation in `build-jar.sh`. Couldn't compile without that because my system uses windows-1250 encoding and there were some unmappable characters. `javac` by default uses system encoding and windows doesn't use UTF-8 as default.

I also added UTF-8 encoding in `test.sh` for consistency. Also edited `javac` command in `test.sh` to work in MinGW and Cygwin - windows uses `;` for seperating classpaths instead of `:`.