### PR TITLE
Add binary literal

### DIFF
--- a/src/rars/util/Binary.java
+++ b/src/rars/util/Binary.java
@@ -414,6 +414,18 @@ public class Binary {
                     return null;
                 }
             }
+        }else if(s.length() > 2+i && s.charAt(i) == '0' && (s.charAt(i+1) == 'b' || s.charAt(i+1) == 'B')) { // Binary case
+            if(s.length() > 32+2+i) return null; // This must overflow or contain invalid characters
+            i += 2;
+            for(; i < s.length(); i++) {
+                char c = s.charAt(i);
+                result *= 2;
+                if ('0' <= c && c <= '1') {
+                    result += c - '0';
+                } else {
+                    return null;
+                }
+            }
         }else if (first == '0'){ // Octal case
             if(s.length() > 12+i) return null; // This must overflow or contain invalid characters
             for(; i < s.length(); i++){

--- a/test/literal.s
+++ b/test/literal.s
@@ -1,0 +1,14 @@
+#stdout:168
+.text
+main:
+	li a0, 42
+	addi a0, a0, '*'
+	addi a0, a0, 0x2a
+	addi a0, a0, 0b101010
+	li a7, 1 # print integer
+	ecall
+
+success:
+	li a0, 42
+	li a7, 93
+	ecall


### PR DESCRIPTION
Add binary literal syntax, e.g. `0b101010`.

Decimal, hexadecimal, and octal are already handled, but binary was missing.
Binary literals are useful for testing flags and to teach binary to students.

This is consistent with the GNU assembler syntax that accept it https://sourceware.org/binutils/docs-2.40/as/Integers.html

Add also some simple tests on integer literals.