### PR TITLE
Improve readChar

### DIFF
--- a/src/rars/riscv/syscalls/SyscallReadChar.java
+++ b/src/rars/riscv/syscalls/SyscallReadChar.java
@@ -36,7 +36,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 public class SyscallReadChar extends AbstractSyscall {
     public SyscallReadChar() {
-        super("ReadChar", "Reads a character from input console", "N/A", "a0 = the character");
+        super("ReadChar", "Reads a character from input console", "N/A", "a0 = the character or -1 if end of input.");
     }
 
     public void simulate(ProgramStatement statement) throws ExitingException {

--- a/src/rars/riscv/syscalls/SyscallReadString.java
+++ b/src/rars/riscv/syscalls/SyscallReadString.java
@@ -50,7 +50,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 public class SyscallReadString extends AbstractSyscall {
     public SyscallReadString() {
         super("ReadString", "Reads a string from the console",
-                "a0 = address of input buffer<br>a1 = maximum number of characters to read", "N/A");
+                "a0 = address of input buffer<br>a1 = size of the buffer", "N/A");
     }
 
     public void simulate(ProgramStatement statement) throws ExitingException {

--- a/test/Test.java
+++ b/test/Test.java
@@ -89,7 +89,7 @@ public class Test {
                     for(int i = 0; i < linenumbers.length; i++){
                         errorlines[i] = Integer.parseInt(linenumbers[i].trim());
                     }
-                } else if (line.startsWith("stdin:")) {
+                } else if (line.startsWith("#stdin:")) {
                     stdin = line.replaceFirst("#stdin:", "").replaceAll("\\\\n","\n");
                 } else if (line.startsWith("#stdout:")) {
                     stdout = line.replaceFirst("#stdout:", "").replaceAll("\\\\n","\n");

--- a/test/read.s
+++ b/test/read.s
@@ -1,0 +1,73 @@
+#stdin:hello\nworldXremain
+#stdout:11hello\nworld....\n1Xello\nworld....\n0Xello\nworld....\n6remainworld....\n0remainworld....\n
+
+.eqv PrintInt, 1
+.eqv Read, 63
+.eqv PrintString, 4
+
+# Expect to read one and half line "hello\nworld"
+li a0, 0
+la a1, buf
+li a2, 11
+li a7, Read
+ecall
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read only a character
+li a0, 0
+la a1, buf
+li a2, 1
+li a7, Read
+ecall
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read nothing
+li a0, 0
+la a1, buf
+li a2, 0 # nothing
+li a7, Read
+ecall
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read what remains
+li a0, 0
+la a1, buf
+li a2, 12
+li a7, Read
+ecall
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read nothing, it's EOF
+li a0, 0
+la a1, buf
+li a2, 12
+li a7, Read
+ecall
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+li a0, 42 
+li a7, 93	# Exit2
+ecall
+
+.data
+buf: .string "...............\n"

--- a/test/readchar.s
+++ b/test/readchar.s
@@ -1,0 +1,24 @@
+#stdin:a b\n\n!
+#stdout:97a32 98b10\n10\n33!-1ÿ-1ÿ
+
+.eqv PrintInt, 1
+.eqv ReadChar, 12
+.eqv PrintChar, 11
+
+li s0, 8
+loop:
+beqz s0, end
+addi s0, s0, -1
+li a7, ReadChar
+ecall
+li a7, PrintInt
+ecall
+# Note: lowest byte of -1 is ff, and U+FF is ÿ
+li a7, PrintChar
+ecall
+j loop
+
+end:
+li a0, 42 
+li a7, 93	# Exit2
+ecall

--- a/test/readstring.s
+++ b/test/readstring.s
@@ -1,0 +1,100 @@
+#stdin:hello\n\nworldNOTWORLD\nXXXX\nYYYY\nremain
+#stdout:0hello\n1\n2world34A5remain\n6\n
+
+.eqv PrintInt, 1
+.eqv ReadString, 8
+.eqv PrintString, 4
+
+# Expect to read one line "hello\n"
+la a0, buf
+li a1, 256
+li a7, ReadString
+ecall
+li a0, 0
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read an empty line
+la a0, buf
+li a1, 256
+li a7, ReadString
+ecall
+li a0, 1
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read "world" only
+la a0, buf
+li a1, 6 # include space for '\0'
+li a7, ReadString
+ecall
+li a0, 2
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read nothing
+la a0, buf
+li a1, 1 # only space for a nullbyte
+li a7, ReadString
+ecall
+li a0, 3
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read nothing
+la a0, buf
+li a1, 'A'
+sb a1, 0(a0)
+sb zero, 1(a0) # Initialize buffer with "A\0"
+li a1, 0 # no space for a nullbyte
+li a7, ReadString
+ecall
+li a0, 4
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read the last line, a "\n" is added
+la a0, buf
+li a1, 256
+li a7, ReadString
+ecall
+li a0, 5
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+# Expect to read only an added "\n". ReadString has no concept of EOF
+la a0, buf
+li a1, 256
+li a7, ReadString
+ecall
+li a0, 6
+li a7, PrintInt
+ecall
+la a0, buf
+li a7, PrintString
+ecall
+
+li a0, 42 
+li a7, 93	# Exit2
+ecall
+
+.data
+buf: .space 256


### PR DESCRIPTION
readChar has various issues:

* it consumes a whole line of text, truncate it at the first character and lose what remain
* is not able to read newline character (it just aborts)
* also aborts on EOF

This PR proposes that:

* readChar reads the next byte in the input (run panel or stdin) and use it as the result
* `\n` is not special and just return 10
* return -1 (signed 32/64 bit) on EOF

The PR also add tests for readChar, readString and read