### PR TITLE
MessagesPane: Force black text color on yellow selection

### DIFF
--- a/src/rars/venus/MessagesPane.java
+++ b/src/rars/venus/MessagesPane.java
@@ -114,6 +114,7 @@ public class MessagesPane extends JTabbedPane {
                             if (text.startsWith(ErrorList.ERROR_MESSAGE_PREFIX) || text.startsWith(ErrorList.WARNING_MESSAGE_PREFIX)) {
                                 assemble.select(lineStart, lineEnd);
                                 assemble.setSelectionColor(Color.YELLOW);
+                                assemble.setSelectedTextColor(Color.BLACK);
                                 assemble.repaint();
                                 int separatorPosition = text.indexOf(ErrorList.MESSAGE_SEPARATOR);
                                 if (separatorPosition >= 0) {
@@ -214,6 +215,7 @@ public class MessagesPane extends JTabbedPane {
                 lineStart = assemble.getLineStartOffset(textLine);
                 lineEnd = assemble.getLineEndOffset(textLine);
                 assemble.setSelectionColor(Color.YELLOW);
+                assemble.setSelectedTextColor(Color.BLACK);
                 assemble.select(lineStart, lineEnd);
                 assemble.getCaret().setSelectionVisible(true);
                 assemble.repaint();


### PR DESCRIPTION
When using different swing look and feel (LAF), the yellow highlight on assembly error can make the message hard to read if the LAF uses the white color for selected texts.

A simple solution is to force the black text, so it is readable on a yellow background.

Note: I use the following to run rars with flatlaf

```
java -cp "lib/flatlaf-3.1.1.jar:rars.jar" -Dswing.defaultlaf=com.formdev.flatlaf.FlatIntelliJLaf rars.Launch
```