### PR TITLE
Various memory fixes for RV64

### DIFF
--- a/src/PseudoOps-64.txt
+++ b/src/PseudoOps-64.txt
@@ -34,3 +34,8 @@ ld t1,-100     ;ld RG1, VL2(x0) ;#Load Double word : Set t1 to contents of effec
 ld t1,10000000 ;lui   RG1, VH2  ;ld RG1, VL2(RG1)  ;#Load Double word : Set t1 to contents of effective memory word address
 ld t1,label	   ;auipc RG1, PCH2 ;ld RG1, PCL2(RG1) ;#Load Double word : Set t1 to contents of memory word at label's address
 ld t1,%lo(label)(t2)  ;ld RG1,LL4(RG7)  ;#Load from Address
+
+sd t1,(t2)        ;sd RG1,0(RG3)   ;#Store Double Word : Store t1 contents into effective memory word address
+sd t1,-100        ;sd RG1, VL2(x0) ;#Store Double Word : Store $t1 contents into effective memory word address
+sd t1,10000000,t2 ;lui   RG3, VH2  ;sd RG1, VL2(RG3)  ;#Store Double Word : Store $t1 contents into effective memory word address using t2 as a temporary
+sd t1,label,t2    ;auipc RG3, PCH2 ;sd RG1, PCL2(RG3) ;#Store Double Word : Store $t1 contents into memory word at label's address using t2 as a temporary

--- a/src/rars/riscv/hardware/Memory.java
+++ b/src/rars/riscv/hardware/Memory.java
@@ -5,6 +5,7 @@ import rars.ProgramStatement;
 import rars.Settings;
 import rars.SimulationException;
 import rars.riscv.Instruction;
+import rars.riscv.InstructionSet;
 import rars.util.Binary;
 
 import java.util.Collection;
@@ -337,7 +338,7 @@ public class Memory extends Observable {
      * Returns the next available word-aligned heap address.  There is no recycling and
      * no heap management!  There is however nearly 4MB of heap space available in Rars.
      *
-     * @param numBytes Number of bytes requested.  Should be multiple of 4, otherwise next higher multiple of 4 allocated.
+     * @param numBytes Number of bytes requested.  Should be multiple of the architecture size (4 in RV32 or 8 in RV64) , otherwise next higher multiple of the arch size allocated.
      * @return address of allocated heap storage.
      * @throws IllegalArgumentException if number of requested bytes is negative or exceeds available heap storage
      */
@@ -347,8 +348,9 @@ public class Memory extends Observable {
             throw new IllegalArgumentException("request (" + numBytes + ") is negative heap amount");
         }
         int newHeapAddress = heapAddress + numBytes;
-        if (newHeapAddress % 4 != 0) {
-            newHeapAddress = newHeapAddress + (4 - newHeapAddress % 4); // next higher multiple of 4
+        int size = InstructionSet.rv64 ? 8 : 4;
+        if (newHeapAddress % size != 0) {
+            newHeapAddress = newHeapAddress + (size - newHeapAddress % size); // next higher multiple of 4
         }
         if (newHeapAddress >= dataSegmentLimitAddress) {
             throw new IllegalArgumentException("request (" + numBytes + ") exceeds available heap storage");

--- a/src/rars/riscv/hardware/Memory.java
+++ b/src/rars/riscv/hardware/Memory.java
@@ -377,6 +377,10 @@ public class Memory extends Observable {
 
     // Allocates blocks if necessary.
     public int set(int address, int value, int length) throws AddressErrorException {
+        // This method is very complex and produce wrong results if length>4
+        // So clamp the length to 4
+        if (length > 4) length = 4;
+
         int oldValue = 0;
         if (Globals.debug) System.out.println("memory[" + address + "] set to " + value + "(" + length + " bytes)");
         int relativeByteAddress;

--- a/test/dword.s
+++ b/test/dword.s
@@ -1,0 +1,25 @@
+#stdout:87654321HGFEDCBA0x100100000x00000000
+.data
+data:
+.eqv eqv, 0x3132333435363738
+.dword eqv
+.dword 0x4142434445464748
+
+data2: .dword data
+.byte 0
+
+.text
+li a7, 4 # PrintString
+la a0, data
+ecall
+
+la s1, data2
+li a7, 34 # PrintIntHex
+lw a0, 0(s1)
+ecall
+lw a0, 4(s1)
+ecall
+
+li a7, 93 # Exit2
+li a0, 42
+ecall


### PR DESCRIPTION
* fix broken memory with `.dword label`
* Sbrk align on 8 bytes in rv64
* add missing pseudo-ops for `sd` (`ld` pseudo-ops were present)