### PR TITLE
Bundle and use flatlaf by default

### DIFF
--- a/build-jar-flatlaf.sh
+++ b/build-jar-flatlaf.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+flatlaf="flatlaf-3.2.jar"
+
+if [ ! -f "$flatlaf" ]; then
+	curl https://repo1.maven.org/maven2/com/formdev/flatlaf/3.2/flatlaf-3.2.jar -o "$flatlaf"
+fi
+
+rm -r tmp/
+mkdir -p tmp/
+cd tmp/
+
+
+jar x < ../rars.jar
+jar x < "../$flatlaf"
+
+cat > META-INF/MANIFEST.MF <<EOF
+Manifest-Version: 1.0
+Implementation-Version: 3.1.1
+Multi-Release: true
+Main-Class: rars.Launch
+EOF
+
+jar cfm ../rars-flatlaf.jar META-INF/MANIFEST.MF *

--- a/src/rars/Launch.java
+++ b/src/rars/Launch.java
@@ -231,6 +231,11 @@ public class Launch {
 
     private void launchIDE() {
         // System.setProperty("apple.laf.useScreenMenuBar", "true"); // Puts RARS menu on Mac OS menu bar
+        try {
+            UIManager.setLookAndFeel("com.formdev.flatlaf.FlatIntelliJLaf");
+        } catch( Exception ex ) {
+            System.err.println( "Failed to initialize LaF. Continue with default LaF." );
+        }
         SwingUtilities.invokeLater(
                 new Runnable() {
                     public void run() {


### PR DESCRIPTION
Add a script to download and use flatlaf by default https://www.formdev.com/flatlaf/

Merging jar is done at low level, as RARS does no use a build tool like Maven or Gradle.

![rars-flatlaf](https://github.com/TheThirdOne/rars/assets/135828/03801528-430d-4257-bbac-468f97e59c40)
