### PR TITLE
build-jar: force release 8

### DIFF
--- a/build-jar.sh
+++ b/build-jar.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if git submodule status | grep \( > /dev/null ; then 
     mkdir -p build
-    find src -name "*.java" | xargs javac -d build
+    find src -name "*.java" | xargs javac --release 8 -d build
     if [[ "$OSTYPE" == "darwin"* ]]; then
         find src -type f -not -name "*.java" -exec rsync -R {} build \;
     else


### PR DESCRIPTION
Ensure that build-jar produce jar files compatible with commons java vm