### PR TITLE
fix: Swing Thread Lock during MMIO / Display Character

### DIFF
--- a/src/rars/tools/KeyboardAndDisplaySimulator.java
+++ b/src/rars/tools/KeyboardAndDisplaySimulator.java
@@ -288,54 +288,64 @@ public class KeyboardAndDisplaySimulator extends AbstractToolAndApplication {
     // Once the latter is performed, the display mode changes to random
     // access, which has repercussions for the implementation of character display.
     private void displayCharacter(int intWithCharacterToDisplay) {
-        char characterToDisplay = (char) (intWithCharacterToDisplay & 0x000000FF);
-        if (characterToDisplay == CLEAR_SCREEN) {
-            initializeDisplay(displayRandomAccessMode);
-        } else if (characterToDisplay == SET_CURSOR_X_Y) {
-            // First call will activate random access mode.
-            // We're using JTextArea, where caret has to be within text.
-            // So initialize text to all spaces to fill the JTextArea to its
-            // current capacity.  Then set caret.  Subsequent character
-            // displays will replace, not append, in the text.
-            if (!displayRandomAccessMode) {
-                displayRandomAccessMode = true;
-                initializeDisplay(displayRandomAccessMode);
-            }
-            // For SET_CURSOR_X_Y, we need data from the rest of the word.
-            // High order 3 bytes are split in half to store (X,Y) value.
-            // High 12 bits contain X value, next 12 bits contain Y value.
-            int x = (intWithCharacterToDisplay & 0xFFF00000) >>> 20;
-            int y = (intWithCharacterToDisplay & 0x000FFF00) >>> 8;
-            // If X or Y values are outside current range, set to range limit.
-            if (x < 0) x = 0;
-            if (x >= columns) x = columns - 1;
-            if (y < 0) y = 0;
-            if (y >= rows) y = rows - 1;
-            // display is a JTextArea whose character positioning in the text is linear.
-            // Converting (row,column) to linear position requires knowing how many columns
-            // are in each row.  I add one because each row except the last ends with '\n' that
-            // does not count as a column but occupies a position in the text string.
-            // The values of rows and columns is set in initializeDisplay().
-            display.setCaretPosition(y * (columns + 1) + x);
-        } else {
-            if (displayRandomAccessMode) {
-                try {
-                    int caretPosition = display.getCaretPosition();
-                    // if caret is positioned at the end of a line (at the '\n'), skip over the '\n'
-                    if ((caretPosition + 1) % (columns + 1) == 0) {
-                        caretPosition++;
-                        display.setCaretPosition(caretPosition);
+        // using invokeLater as a way to queue up appending character to display, if there is a reason why this shoudn't be done, please let me know! Hi from Jesus A!
+        SwingUtilities.invokeLater(
+            new Runnable(){
+              public void run() {
+                
+                char characterToDisplay = (char) (intWithCharacterToDisplay & 0x000000FF);
+                if (characterToDisplay == CLEAR_SCREEN) {
+                    initializeDisplay(displayRandomAccessMode);
+                } else if (characterToDisplay == SET_CURSOR_X_Y) {
+                    // First call will activate random access mode.
+                    // We're using JTextArea, where caret has to be within text.
+                    // So initialize text to all spaces to fill the JTextArea to its
+                    // current capacity.  Then set caret.  Subsequent character
+                    // displays will replace, not append, in the text.
+                    if (!displayRandomAccessMode) {
+                        displayRandomAccessMode = true;
+                        initializeDisplay(displayRandomAccessMode);
                     }
-                    display.replaceRange("" + characterToDisplay, caretPosition, caretPosition + 1);
-                } catch (IllegalArgumentException e) {
-                    // tried to write off the end of the defined grid.
-                    display.setCaretPosition(display.getCaretPosition() - 1);
-                    display.replaceRange("" + characterToDisplay, display.getCaretPosition(), display.getCaretPosition() + 1);
-                }
-            } else {
-                display.append("" + characterToDisplay);
-            }
-        }
+                    // For SET_CURSOR_X_Y, we need data from the rest of the word.
+                    // High order 3 bytes are split in half to store (X,Y) value.
+                    // High 12 bits contain X value, next 12 bits contain Y value.
+                    int x = (intWithCharacterToDisplay & 0xFFF00000) >>> 20;
+                    int y = (intWithCharacterToDisplay & 0x000FFF00) >>> 8;
+                    // If X or Y values are outside current range, set to range limit.
+                    if (x < 0) x = 0;
+                    if (x >= columns) x = columns - 1;
+                    if (y < 0) y = 0;
+                    if (y >= rows) y = rows - 1;
+                    // display is a JTextArea whose character positioning in the text is linear.
+                    // Converting (row,column) to linear position requires knowing how many columns
+                    // are in each row.  I add one because each row except the last ends with '\n' that
+                    // does not count as a column but occupies a position in the text string.
+                    // The values of rows and columns is set in initializeDisplay().
+                    display.setCaretPosition(y * (columns + 1) + x);
+                } 
+                else {
+                    if (displayRandomAccessMode) {
+                        try {
+                            int caretPosition = display.getCaretPosition();
+                            // if caret is positioned at the end of a line (at the '\n'), skip over the '\n'
+                            if ((caretPosition + 1) % (columns + 1) == 0) {
+                                caretPosition++;
+                                display.setCaretPosition(caretPosition);
+                            }
+                            display.replaceRange("" + characterToDisplay, caretPosition, caretPosition + 1);
+                        } catch (IllegalArgumentException e) {
+                            // tried to write off the end of the defined grid.
+                            display.setCaretPosition(display.getCaretPosition() - 1);
+                            display.replaceRange("" + characterToDisplay, display.getCaretPosition(), display.getCaretPosition() + 1);
+                        }
+                    }
+                    else {
+                        display.append("" + characterToDisplay);
+                        }
+                    }
+              }
+            }    
+        );
     }
 
     @Override


### PR DESCRIPTION
# Issue: Display Freeze during MMIO Output

Hi, I am opening a PR in regard to to an issue I was having when printing characters to MMIO, it would randomly freeze, the sp would always vary, so I took a look at the stack trace during program execution. 

I also saw that someone else had a similar issue a couple years ago, but it was seemingly fixed: [link here](https://github.com/TheThirdOne/rars/issues/82)

## Stack Trace
 "RISCV" #55 [126983] prio=4 os_prio=31 cpu=389.33ms elapsed=261.90s tid=0x000000013d48c400 nid=126983 waiting for monitor entry  [0x00000002fc641000]

   **java.lang.Thread.State: BLOCKED (on object monitor)**

	at java.awt.Component$AccessibleAWTComponent.getLocationOnScreen(java.desktop@21/Component.java:9802)
	- waiting to lock <0x000000070042e9f0> (a java.awt.Component$AWTTreeLock)
	at javax.swing.JComponent$AccessibleJComponent.getLocationOnScreen(java.desktop@21/JComponent.java:3735)
	at javax.swing.text.JTextComponent$AccessibleJTextComponent.caretUpdate(java.desktop@21/JTextComponent.java:2622)
	at javax.swing.text.JTextComponent.fireCaretUpdate(java.desktop@21/JTextComponent.java:408)
	at javax.swing.text.JTextComponent$MutableCaretEvent.fire(java.desktop@21/JTextComponent.java:4484)
	at javax.swing.text.JTextComponent$MutableCaretEvent.stateChanged(java.desktop@21/JTextComponent.java:4506)
	at javax.swing.text.DefaultCaret.fireStateChanged(java.desktop@21/DefaultCaret.java:857)
	at com.apple.laf.AquaCaret.fireStateChanged(java.desktop@21/AquaCaret.java:86)
	at javax.swing.text.DefaultCaret.changeCaretPosition(java.desktop@21/DefaultCaret.java:1343)
	at javax.swing.text.DefaultCaret.handleSetDot(java.desktop@21/DefaultCaret.java:1242)
	at javax.swing.text.DefaultCaret.setDot(java.desktop@21/DefaultCaret.java:1223)
	at javax.swing.text.DefaultCaret$Handler.insertUpdate(java.desktop@21/DefaultCaret.java:1819)
	at javax.swing.text.AbstractDocument.fireInsertUpdate(java.desktop@21/AbstractDocument.java:227)
	at javax.swing.text.AbstractDocument.handleInsertString(java.desktop@21/AbstractDocument.java:781)
	at javax.swing.text.AbstractDocument.insertString(java.desktop@21/AbstractDocument.java:740)
	at javax.swing.text.PlainDocument.insertString(java.desktop@21/PlainDocument.java:131)
	at javax.swing.JTextArea.append(java.desktop@21/JTextArea.java:482)

	**at rars.tools.KeyboardAndDisplaySimulator.displayCharacter(KeyboardAndDisplaySimulator.java:336)
	at rars.tools.KeyboardAndDisplaySimulator.processRISCVUpdate(KeyboardAndDisplaySimulator.java:253)**

	at rars.tools.AbstractToolAndApplication.update(AbstractToolAndApplication.java:480)
	at java.util.Observable.notifyObservers(java.base@21/Observable.java:174)
	at rars.riscv.hardware.Memory$MemoryObservable.notifyObserver(Memory.java:1126)
	at rars.riscv.hardware.Memory.notifyAnyObservers(Memory.java:1156)
	at rars.riscv.hardware.Memory.set(Memory.java:428)
	at rars.riscv.hardware.Memory.setWord(Memory.java:500)
	at rars.riscv.instructions.SW.store(SW.java:39)
	at rars.riscv.instructions.Store.simulate(Store.java:57)
	at rars.simulator.Simulator$SimThread.run(Simulator.java:484)
	at java.lang.Thread.runWith(java.base@21/Thread.java:1596)
	at java.lang.Thread.run(java.base@21/Thread.java:1583)

## Solution
I simply used Swing's invokeLater function to queue up the display of a new character. 
