### PR TITLE
fix: terminally deprecated feature

### DIFF
--- a/src/rars/venus/NumberDisplayBaseChooser.java
+++ b/src/rars/venus/NumberDisplayBaseChooser.java
@@ -221,7 +221,7 @@ public class NumberDisplayBaseChooser extends JCheckBox {
         if (base == NumberDisplayBaseChooser.HEXADECIMAL) {
             return Binary.intToHexString(value);
         } else {
-            return new Integer(value).toString();
+            return String.valueOf(value);
         }
     }
 


### PR DESCRIPTION
During building with a modern jdk, the following warning occurs:

`warning: [removal] Integer(int) in Integer has been deprecated and marked for removal`

PR fixes that. There are also a lot more warnings because of the deprecated Observer class as well as some unchecked/unsafe operations, but those are a topic for another time :)