### PR TITLE
Issue #189 Enhancement: Added GUI scale button to settings

### DIFF
--- a/src/rars/venus/VenusUI.java
+++ b/src/rars/venus/VenusUI.java
@@ -86,7 +86,7 @@ public class VenusUI extends JFrame {
     private JCheckBoxMenuItem settingsLabel, settingsPopupInput, settingsValueDisplayBase, settingsAddressDisplayBase,
             settingsExtended, settingsAssembleOnOpen, settingsAssembleAll, settingsAssembleOpen, settingsWarningsAreErrors,
             settingsStartAtMain, settingsProgramArguments, settingsSelfModifyingCode, settingsRV64, settingsDeriveCurrentWorkingDirectory;
-    private JMenuItem settingsExceptionHandler, settingsEditor, settingsHighlighting, settingsMemoryConfiguration;
+    private JMenuItem settingsExceptionHandler, settingsEditor, settingsHighlighting, settingsMemoryConfiguration, settingsScaleConfiguration;
     private JMenuItem helpHelp, helpAbout;
 
     // components of the toolbar
@@ -110,7 +110,7 @@ public class VenusUI extends JFrame {
             settingsExtendedAction, settingsAssembleOnOpenAction, settingsAssembleOpenAction, settingsAssembleAllAction,
             settingsWarningsAreErrorsAction, settingsStartAtMainAction, settingsProgramArgumentsAction,
             settingsExceptionHandlerAction, settingsEditorAction, settingsHighlightingAction, settingsMemoryConfigurationAction,
-            settingsSelfModifyingCodeAction, settingsRV64Action, settingsDeriveCurrentWorkingDirectoryAction;
+            settingsScaleAction, settingsSelfModifyingCodeAction, settingsRV64Action, settingsDeriveCurrentWorkingDirectoryAction;
     private Action helpHelpAction, helpAboutAction;
 
 
@@ -493,6 +493,8 @@ public class VenusUI extends JFrame {
                     null, null
             );
 
+            settingsScaleAction = new SettingsScaleAction("Scale GUI", null, "Scale the GUI by a factor of 2 (Relaunches the application)", null, null);
+
             helpHelpAction = new HelpHelpAction("Help", loadIcon("Help22.png"),
                     "Help", KeyEvent.VK_H, KeyStroke.getKeyStroke(KeyEvent.VK_F1, 0), mainUI);
             helpAboutAction = new HelpAboutAction("About ...", null,
@@ -647,6 +649,8 @@ public class VenusUI extends JFrame {
         settingsHighlighting = new JMenuItem(settingsHighlightingAction);
         settingsExceptionHandler = new JMenuItem(settingsExceptionHandlerAction);
         settingsMemoryConfiguration = new JMenuItem(settingsMemoryConfigurationAction);
+        settingsScaleConfiguration = new JMenuItem(settingsScaleAction);
+
 
         settings.add(settingsLabel);
         settings.add(settingsProgramArguments);
@@ -669,6 +673,7 @@ public class VenusUI extends JFrame {
         settings.add(settingsHighlighting);
         settings.add(settingsExceptionHandler);
         settings.add(settingsMemoryConfiguration);
+        settings.add(settingsScaleConfiguration);
 
         helpHelp = new JMenuItem(helpHelpAction);
         helpHelp.setIcon(loadIcon("Help16.png"));//"Help16.gif"));
@@ -837,6 +842,7 @@ public class VenusUI extends JFrame {
         editFindReplaceAction.setEnabled(false);
         editSelectAllAction.setEnabled(false);
         settingsMemoryConfigurationAction.setEnabled(true); // added 21 July 2009
+        settingsScaleAction.setEnabled(true); // added 10 March 2025
         runAssembleAction.setEnabled(false);
         runGoAction.setEnabled(false);
         runStepAction.setEnabled(false);
@@ -871,6 +877,7 @@ public class VenusUI extends JFrame {
         editFindReplaceAction.setEnabled(true);
         editSelectAllAction.setEnabled(true);
         settingsMemoryConfigurationAction.setEnabled(true);
+        settingsScaleAction.setEnabled(true);
         runAssembleAction.setEnabled(true);
         // If assemble-all, allow previous Run menu settings to remain.
         // Otherwise, clear them out.  DPS 9-Aug-2011
@@ -907,6 +914,7 @@ public class VenusUI extends JFrame {
         editFindReplaceAction.setEnabled(true);
         editSelectAllAction.setEnabled(true);
         settingsMemoryConfigurationAction.setEnabled(true); // added 21 July 2009
+        settingsScaleAction.setEnabled(true); // added 10 March 2025 
         runAssembleAction.setEnabled(true);
         runGoAction.setEnabled(false);
         runStepAction.setEnabled(false);
@@ -940,6 +948,7 @@ public class VenusUI extends JFrame {
         editFindReplaceAction.setEnabled(true);
         editSelectAllAction.setEnabled(true);
         settingsMemoryConfigurationAction.setEnabled(true); // added 21 July 2009
+        settingsScaleAction.setEnabled(true);
         runAssembleAction.setEnabled(false);
         runGoAction.setEnabled(false);
         runStepAction.setEnabled(false);
@@ -973,6 +982,7 @@ public class VenusUI extends JFrame {
         editFindReplaceAction.setEnabled(true);
         editSelectAllAction.setEnabled(true);
         settingsMemoryConfigurationAction.setEnabled(true); // added 21 July 2009
+        settingsScaleAction.setEnabled(true); // added 10 March 2025
         runAssembleAction.setEnabled(true);
         runGoAction.setEnabled(true);
         runStepAction.setEnabled(true);
@@ -1006,6 +1016,7 @@ public class VenusUI extends JFrame {
         editFindReplaceAction.setEnabled(false);
         editSelectAllAction.setEnabled(false);
         settingsMemoryConfigurationAction.setEnabled(false); // added 21 July 2009
+        settingsScaleAction.setEnabled(true); // added 10 March 2025
         runAssembleAction.setEnabled(false);
         runGoAction.setEnabled(false);
         runStepAction.setEnabled(false);
@@ -1039,6 +1050,7 @@ public class VenusUI extends JFrame {
         editFindReplaceAction.setEnabled(true);
         editSelectAllAction.setEnabled(true);
         settingsMemoryConfigurationAction.setEnabled(true); // added 21 July 2009
+        settingsScaleAction.setEnabled(true); // added 10 March 2025
         runAssembleAction.setEnabled(true);
         runGoAction.setEnabled(false);
         runStepAction.setEnabled(false);

--- a/src/rars/venus/settings/SettingsScaleAction.java
+++ b/src/rars/venus/settings/SettingsScaleAction.java
@@ -82,7 +82,7 @@ public class SettingsScaleAction extends GuiAction {
             processBuilder.start();
         } 
         catch(Exception ex) {
-            // Do nothing if the above fails. 
+            // Do nothing if the above fails
         }
     }
 

--- a/src/rars/venus/settings/SettingsScaleAction.java
+++ b/src/rars/venus/settings/SettingsScaleAction.java
@@ -1,0 +1,111 @@
+package rars.venus.settings;
+
+import rars.Globals;
+import rars.simulator.Simulator;
+import rars.util.Binary;
+import rars.venus.FileStatus;
+import rars.venus.GuiAction;
+import rars.venus.VenusUI;
+import rars.Launch;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+import java.net.URI;
+
+	/*
+Copyright (c) 2003-2009,  Pete Sanderson and Kenneth Vollmar
+
+Developed by Pete Sanderson (psanderson@otterbein.edu)
+and Kenneth Vollmar (kenvollmar@missouristate.edu)
+
+Permission is hereby granted, free of charge, to any person obtaining 
+a copy of this software and associated documentation files (the 
+"Software"), to deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, merge, publish, 
+distribute, sublicense, and/or sell copies of the Software, and to 
+permit persons to whom the Software is furnished to do so, subject 
+to the following conditions:
+
+The above copyright notice and this permission notice shall be 
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+(MIT license, http://www.opensource.org/licenses/mit-license.html)
+ */
+
+/**
+ * Action class for the Settings menu item for text editor settings.
+ */
+public class SettingsScaleAction extends GuiAction {
+    /**
+     * Create a new SettingsEditorAction. Has all the GuiAction parameters.
+     */
+    public SettingsScaleAction(String name, Icon icon, String descrip,
+                                             Integer mnemonic, KeyStroke accel) {
+        super(name, icon, descrip, mnemonic, accel);
+    }
+
+    /**
+     * When this action is triggered, scale the GUI by a factor of 2. 
+     * This is done by relaunching the GUI. 
+     */
+    public void actionPerformed(ActionEvent e) {
+        try{
+            // Get the absolute path of the rars jar file 
+            String jar = findJarFile().getAbsolutePath();
+
+            // Relaunch the jar with the uiScale set to 2.0 
+            ProcessBuilder processBuilder = new ProcessBuilder(
+                "java", "-Dsun.java2d.uiScale=2.0", "-jar", jar);
+            processBuilder.start();
+        } 
+        catch(Exception ex) {
+            // Do nothing if the above fails. 
+        }
+    }
+
+    /**
+     * This function is used by actionPerformed to find the absolute path to the rars jar file. 
+     */
+    private static File findJarFile() {
+    try {
+        // Gets the file location where the original jar was executed 
+        URI uri = Launch.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+        Path dir = Paths.get(uri);
+
+        // Search recursively in subdirectories for "*rars*.jar"
+        try (Stream<Path> paths = Files.walk(dir)) {
+            return paths.filter(path -> path.toString().matches("^.*rars.*\\.jar$"))
+                        .map(Path::toFile)
+                        .findFirst()
+                        .orElse(null);  // No matching JAR found
+        }
+    } 
+    catch (Exception e) {
+    }
+        // Return null if the above fails. 
+        return null; 
+    }
+}


### PR DESCRIPTION
Suggested addition for isssue #189 
An issue on certain resolutions is that the GUI is too small to see. The current workaround is to execute the jar using `java -Dsun.java2d.uiScale=2.0 -jar rars1_6.jar`

This PR adds the "Scale GUI" button to the settings tab. Clicking "Scale GUI" relaunches the jar with the flag -Dsun.java2d.uiScale=2.0. 

I created the SettingsScaleAction class in the src/rars/venus/settings directory, and added it to src/rars/venus/VenusUI.java. SettingsScaleAction finds the absolute path of the jar file, and creates a new process with the -Dsun.java2d.uiScale=2.0 flag. If the absolute path could not be found or the jar cannot be executed, the current process will not crash.

This has been tested on Linux and Windows. 

